### PR TITLE
✨ feat: Generar y guardar enlace de llamada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+jitsi_private_key.pem

--- a/config/models.py
+++ b/config/models.py
@@ -62,6 +62,7 @@ class Appointment(Base):
     SlotId = Column(Integer, ForeignKey("Slots.Id"), nullable=False)
 
     Modality = Column(String(255), nullable=False)
+    MeetingLink = Column(String(2000), nullable=True)
      
     patient = relationship("Patient", back_populates="appointments")
     service = relationship("Service", back_populates="appointments")

--- a/controllers/appointmentController.py
+++ b/controllers/appointmentController.py
@@ -6,6 +6,7 @@ from config.models import Appointment, Patient, Slot, Service
 from sqlalchemy.future import select
 from sqlalchemy.orm import joinedload
 from fastapi import HTTPException
+from utils.jitsi_utils import create_jitsi_meeting
 
 stripe.api_key = "Enter_Your_API_Key"
 
@@ -36,11 +37,15 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
     if serviceCheck is None:
         raise HTTPException(status_code=400, detail="Service not found")
 
-    # Check if the slot is available
+    # Validar modalidad
     if appointment.Modality not in ["Presential", "Virtual"]:
-        raise HTTPException(status_code=400, detail="Modality must be 'Presential' or 'Virtual'")
-    
-    print(f"[BACKEND] Creando cita con modalidad: {appointment.Modality}")
+        raise HTTPException(
+            status_code=400,
+            detail="Modalidad inválida. Debe ser 'Presential' o 'Virtual'"
+        )
+
+    print(f"[BACKEND - CONTROLADOR] Creando cita con modalidad: {appointment.Modality}")
+
 
     newAppointment = Appointment(
         Problem=appointment.Problem,
@@ -48,11 +53,30 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
         PatientId=appointment.PatientId,
         ServiceId=appointment.ServiceId,
         SlotId=appointment.SlotId,
-        Modality=appointment.Modality, 
+        Modality=appointment.Modality,
+        MeetingLink=None  
     )
     db.add(newAppointment)
     await db.commit()
     await db.refresh(newAppointment)
+
+    # Si la modalidad es virtual, generar el enlace de Jitsi Meet
+    if appointment.Modality == "Virtual":
+        try:
+            print(f"[BACKEND - CONTROLADOR] Generando enlace de Jitsi para paciente: {patientCheck.Name}")
+            meeting_info = create_jitsi_meeting(patientCheck.Name, newAppointment.Id)
+            newAppointment.MeetingLink = meeting_info["meeting_url"]
+            await db.commit()
+            await db.refresh(newAppointment)
+            print(f"[BACKEND - CONTROLADOR] Enlace de Jitsi Meet generado: {meeting_info['meeting_url']}")
+        except Exception as e:
+            print(f"[BACKEND - CONTROLADOR]Error al generar enlace de Jitsi Meet: {str(e)}")
+
+    print(f"[BACKEND - CONTROLADOR] Cita creada exitosamente. ID: {newAppointment.Id}, Modalidad: {newAppointment.Modality}")
+    if newAppointment.MeetingLink:
+        print(f"[BACKEND - CONTROLADOR] Link almacenado en BD: {newAppointment.MeetingLink}")
+    else:
+        print("[BACKEND - CONTROLADOR] No se generó link porque no era cita virtual.")
 
     return newAppointment
 
@@ -161,7 +185,7 @@ async def create_payment_link(price_id: str):
             after_completion={
                 "type": "redirect",
                 "redirect": {
-                    "url": "http://localhost:5173/Appointments"  # Change this to your frontend success page
+                    "url": "http://localhost:5173/Appointments"  
                 },
             },
         )

--- a/schemas/appointmentSchemas.py
+++ b/schemas/appointmentSchemas.py
@@ -10,6 +10,7 @@ class AppointmentRequestModel(BaseModel):
     SlotId: int
 
     Modality: str
+    MeetingLink: str | None = None
 
     class Config:
         orm_mode = True
@@ -24,6 +25,9 @@ class AppointmentResponseModel(BaseModel):
     PatientId: int
     ServiceId: int
     SlotId: int
+
+    Modality: str 
+    MeetingLink: str | None
 
     class Config:
         orm_mode = True

--- a/utils/jitsi_utils.py
+++ b/utils/jitsi_utils.py
@@ -1,0 +1,102 @@
+import uuid
+from datetime import datetime, timedelta
+import os
+from jose import jwt
+from dotenv import load_dotenv
+import json
+
+load_dotenv()
+
+# Configuración de JaaS (Jitsi as a Service)
+JITSI_DOMAIN = os.getenv("JITSI_DOMAIN", "8x8.vc")
+JITSI_APP_ID = os.getenv("JITSI_APP_ID", "")
+JITSI_KID = os.getenv("JITSI_KID", "")
+JITSI_PRIVATE_KEY_PATH = os.getenv("JITSI_PRIVATE_KEY_PATH", "jitsi_private_key.pem")
+
+# Leer clave privada
+try:
+    with open(JITSI_PRIVATE_KEY_PATH, "r") as f:
+        JITSI_API_PRIVATE_KEY = f.read()
+except Exception as e:
+    print(f"[JITSI ERROR] No se pudo leer la clave privada: {str(e)}")
+    raise
+
+
+def generate_meeting_id(patient_name: str, appointment_id: int) -> str:
+    """
+    Genera un ID único para la sala de Jitsi (sin timestamp para reutilización).
+    """
+    safe_name = patient_name.lower().replace(" ", "-")
+    return f"telemedicina-{safe_name}-{appointment_id}"
+
+
+def generate_jwt(meeting_id: str) -> str:
+    """
+    Genera un token JWT firmado con la clave privada, con acceso a todas las salas ("room": "*").
+    """
+    payload = {
+        "aud": "jitsi",
+        "iss": "chat",
+        "sub": JITSI_APP_ID,
+        "room": "*",
+        "exp": int((datetime.utcnow() + timedelta(hours=1)).timestamp()),
+        "context": {
+            "user": {
+                "name": "Paciente",
+                "moderator": True
+            }
+        },
+        "features": {
+            "recording": True,
+            "livestreaming": True,
+            "transcription": True,
+            "outbound-call": True
+        }
+    }
+
+    headers = {
+        "alg": "RS256",
+        "kid": JITSI_KID,
+        "typ": "JWT"
+    }
+
+    try:
+        print("[JITSI DEBUG] Header JWT:")
+        print(json.dumps(headers, indent=2))
+        print("[JITSI DEBUG] Payload JWT:")
+        print(json.dumps(payload, indent=2))
+
+        token = jwt.encode(payload, JITSI_API_PRIVATE_KEY, algorithm="RS256", headers=headers)
+
+        print(f"[JITSI DEBUG] Token JWT generado:\n{token}")
+        return token
+    except Exception as e:
+        print(f"[JITSI ERROR] Error generando JWT: {str(e)}")
+        raise
+
+
+def create_jitsi_meeting(patient_name: str, appointment_id: int) -> dict:
+    """
+    Crea la URL de la reunión con token.
+    """
+    try:
+        meeting_id = generate_meeting_id(patient_name, appointment_id)
+        token = generate_jwt(meeting_id)
+        full_domain = f"{JITSI_APP_ID}.{JITSI_DOMAIN}"
+        meeting_url = f"https://{full_domain}/{meeting_id}?jwt={token}"
+
+        print(f"[JITSI] Enlace generado exitosamente: {meeting_url}")
+
+        return {
+            "meeting_id": meeting_id,
+            "meeting_url": meeting_url,
+            "token": token
+        }
+
+    except Exception as e:
+        print(f"[JITSI ERROR] Error creando reunión: {str(e)}")
+        return {
+            "meeting_id": None,
+            "meeting_url": None,
+            "error": str(e)
+        }


### PR DESCRIPTION
### Descripción 

Se implementa la lógica para generar y guardar el enlace de videollamada en la base de datos al momento de registrar una nueva cita médica con modalidad virtual.

### Cambios principales

- Se añadió un campo `MeetingLink` en el modelo de citas.
- Se adaptó la lógica del backend para generar automáticamente el enlace de Jitsi.
- Se actualizó el endpoint de creación de citas para almacenar este enlace.
- Se preparó la base para integrar la funcionalidad de videollamadas en el frontend.

### Contexto

Este cambio forma parte de la implementación de telemedicina en el sistema, permitiendo que cada cita virtual tenga asociada una sala única de videollamada.

## Consideraciones

En este momento solo se presenta dificultades con el JWT que haga match con el de la sala y poder unirse a la sesión
