### PR TITLE
✨ Feat/add email sender

### DIFF
--- a/controllers/appointmentController.py
+++ b/controllers/appointmentController.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 import stripe
@@ -6,9 +7,16 @@ from config.models import Appointment, Patient, Slot, Service
 from sqlalchemy.future import select
 from sqlalchemy.orm import joinedload
 from fastapi import HTTPException
+from dotenv import load_dotenv
+from utils.mail_sender import BuildMail
 
 stripe.api_key = "Enter_Your_API_Key"
 
+load_dotenv()
+
+# Aqui deben de ir las credenciales del correo emisor 
+MAIL_SENDER = os.getenv("EMAIL_SENDER", "")
+MAIL_CREDETENTIALS = os.getenv("EMAIL_APP_PASSWORD", "")
 
 async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSession):
     patientResult = await db.execute(
@@ -62,6 +70,16 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
         await db.commit()
         await db.refresh(newAppointment)
         print(f"[BACKEND] Enlace de Jitsi generado: {meeting_url}")
+        
+        BuildMail (
+                subject=f"Cita de Telemedicina por: {appointment.Problem}",
+                sender=MAIL_SENDER,
+                reciver=patientCheck.Email,
+                credentials=MAIL_CREDETENTIALS,
+                paciente=patientCheck.Name,
+                fecha=appointment.Date,
+                enlace=meeting_url
+            )
 
     print(f"[BACKEND] Cita creada. ID: {newAppointment.Id}, Link: {newAppointment.MeetingLink}")
     return newAppointment

--- a/utils/mail_sender.py
+++ b/utils/mail_sender.py
@@ -1,0 +1,49 @@
+from email.message import EmailMessage
+import ssl
+import smtplib
+
+# Creación de la clase que generara el objeto para construir el email
+class BuildMail:
+
+    def __init__(
+        self,
+        subject: str, # Asunto del correo
+        sender: str, # Dirección de correo del emisor
+        reciver: str, # Dirección de correo del receptor
+        credentials: str, # Contraseña de la aplicación, leer mensaje del pull request para mas info
+        paciente: str, # Nombre del paciente 
+        fecha: str, # Fecha de realización de teleconsulta
+        enlace: str # Enlace de la teleconsulta
+    ):
+        self.msg = EmailMessage() # Construcción del objeto EmailMessage
+        self.msg['Subject'] = subject # Incicalizador de valor Subject
+        self.msg['From'] = sender # Incicalizador de valor From
+        self.msg['To'] = reciver # Incicalizador de valor To
+
+        # Setear el cuerpo del correo 
+        self.msg.set_content(self._build_body(
+            paciente, fecha, enlace
+        ))
+
+        # Envio del correo
+        context = ssl.create_default_context()
+        with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as smtp:
+            smtp.login(sender, credentials)
+            smtp.sendmail(sender, reciver, self.msg.as_string())
+
+    # Construye el mensaje en base a la templeate de abajo
+    def _build_body(self, paciente, fecha, enlace):
+        return f"""\
+        
+Estimado(a) {paciente}:
+
+Le confirmamos su cita de telemedicina programada para:
+
+📅 Fecha: {fecha}  
+🔗 Enlace para la reunión: {enlace}
+
+Le recomendamos conectarse 10 minutos antes del inicio, desde un lugar tranquilo y con buena conexión a internet.  
+Si tiene exámenes recientes o documentos relevantes, tenga a mano sus archivos para compartirlos durante la consulta.
+
+Saludos cordiales.
+"""


### PR DESCRIPTION
Este PR incorpora un servicio de correos integrados backend del sistema de gestión de citas médicas. Esta funcionalidad permite informar acerca de una cita generada a los pacientes a traves de la atención remota.

Cambios realizados
Se añadió lógica para construir y enviar correos con la información de una cita generada.
Se añadio una clase BuildMail para generar el correo dentro de la carpeta utils.
Se modifico la función generadora de citas para enviar a los pacientes mediante su correo electrónico información sobre la teleconsulta.

Información importante para su uso

1. Activar la verificación de 2 pasos (2FA) en la dirección de correo con la que se desea enviar los correos.

2. Entrar a la dirección https://myaccount.google.com/apppasswords, para generar una contraseña del servicio que correra el cliente para el envio de correos.

3. Obtener la contraseña de la aplicación 

4. En las variables de entorno, copiar la dirección mail que se usará para enviar los correos y la contraseña de la aplicación, bajo las siguientes etiquetas: 

EMAIL_SENDER = "micorreo@gmail.com"
EMAIL_APP_PASSWORD = "contraseña de la aplicacion (16 caracteres)"