### PR TITLE
✨Feat: Add initial and expiration time on jitsi sessions

### DIFF
--- a/controllers/appointmentController.py
+++ b/controllers/appointmentController.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 from dotenv import load_dotenv
 from utils.mail_sender import BuildMail
 from datetime import datetime, timedelta
+from utils.timestamps_generators import timestamps_gen
 
 stripe.api_key = "Enter_Your_API_Key"
 
@@ -34,6 +35,7 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
     slotCheck = slotResult.scalars().first()
 
     beginTime = str(slotCheck.Time).split(" - ")[0]
+    endTime = str(slotCheck.Time).split(" - ")[1]
 
     if slotCheck is None:
         raise HTTPException(status_code=400, detail="Slot not found")
@@ -68,6 +70,7 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
     await db.refresh(newAppointment)
 
     if appointment.Modality == "Virtual":
+        nbf_timestamp, exp_timestamp = timestamps_gen(beginTime, endTime, appointment.Date)
         room_name = f"telemedicina-{patientCheck.Name.lower().replace(' ', '')}-{newAppointment.Id}"
         room_name = room_name.replace("ñ", "n")
         meeting_url = f"https://8x8.vc/{os.getenv('JITSI_APP_ID')}/{room_name}"
@@ -76,14 +79,16 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
             user_name=patientCheck.Name,
             user_id=patientCheck.Id,
             room_name=room_name,
-            is_moderator=False
+            is_moderator=False,
+            nbf_time=nbf_timestamp,
+            exp_time=exp_timestamp
         )
 
         print(f"[BACKEND] Jwt de para el paciente generado: {patient_token}")
         
         patient_meeting_link = f"{meeting_url}?jwt={patient_token}"
 
-        newAppointment.MeetingLink = meeting_url
+        newAppointment.MeetingLink = patient_meeting_link
         await db.commit()
         await db.refresh(newAppointment)
         print(f"[BACKEND] Enlace de Jitsi JaaS generado: {meeting_url}")
@@ -97,7 +102,7 @@ async def createAppointment(appointment: AppointmentRequestModel, db: AsyncSessi
                 fecha=str(appointment.Date),
                 enlace=patient_meeting_link,
                 tipo="confirmacion",
-                hora=beginTime
+                hora=beginTime,
             )
 
     print(f"[BACKEND] Cita creada. ID: {newAppointment.Id}, Link: {newAppointment.MeetingLink}")
@@ -111,6 +116,14 @@ async def get_doctor_jitsi_info(appointment_id: int, db: AsyncSession):
     patient = await db.get(Patient, appointment.PatientId)
     if not patient:
         raise HTTPException(status_code=404, detail="Patient not found")
+    
+    slotResult = await db.execute(select(Slot).filter(Slot.Id == appointment.SlotId))
+    slotCheck = slotResult.scalars().first()
+
+    beginTime = str(slotCheck.Time).split(" - ")[0]
+    endTime = str(slotCheck.Time).split(" - ")[1]
+
+    nbf_timestamp, exp_timestamp = timestamps_gen(beginTime, endTime, appointment.Date)
 
     doctor_name = "Dr"
     doctor_id = 1
@@ -119,8 +132,11 @@ async def get_doctor_jitsi_info(appointment_id: int, db: AsyncSession):
         user_id=doctor_id,
         appointment_id=appointment.Id,
         patient_name=patient.Name,
-        is_moderator=True
+        is_moderator=True,
+        nbf_time=nbf_timestamp,
+        exp_time=exp_timestamp
     )
+    print(f"[BACKEND] Respuesta de get_doctor: {result}")
     return result
 
 

--- a/utils/jitsi_utils.py
+++ b/utils/jitsi_utils.py
@@ -18,7 +18,7 @@ def generate_meeting_id(patient_name: str, appointment_id: int) -> str:
     safe_name = patient_name.lower().replace(" ", "").replace("ñ", "n")
     return f"telemedicina-{safe_name}-{appointment_id}"
 
-def generate_jitsi_jwt(user_name, user_id, room_name, is_moderator):
+def generate_jitsi_jwt(user_name, user_id, room_name, is_moderator, nbf_time, exp_time):
     private_key = read_private_key()
 
     print(f"[JITSI DEBUG] Generating JWT for room: {room_name}, user: {user_name}, is_moderator: {is_moderator}")
@@ -32,6 +32,8 @@ def generate_jitsi_jwt(user_name, user_id, room_name, is_moderator):
         .withUserId(str(user_id))
         .withModerator(is_moderator)
         .withLobbyEnabled(True)
+        .withNbfTime(nbf_time)
+        .withExpTime(exp_time)
     )
     token = builder.signWith(private_key)
 
@@ -39,11 +41,11 @@ def generate_jitsi_jwt(user_name, user_id, room_name, is_moderator):
 
     return token.decode("utf-8") if isinstance(token, bytes) else token
 
-def get_jitsi_meeting_link_and_token(user_name, user_id, appointment_id, patient_name, is_moderator):
+def get_jitsi_meeting_link_and_token(user_name, user_id, appointment_id, patient_name, is_moderator, nbf_time, exp_time):
     room_name = generate_meeting_id(patient_name, appointment_id)
     meeting_url = f"https://{JITSI_DOMAIN}/{JITSI_APP_ID}/{room_name}"
 
-    token = generate_jitsi_jwt(user_name, user_id, room_name, is_moderator)
+    token = generate_jitsi_jwt(user_name, user_id, room_name, is_moderator, nbf_time, exp_time)
 
     print(f"[JITSI DEBUG] Meeting URL: {meeting_url}")
     print(f"[JITSI DEBUG] Token: {token}")

--- a/utils/timestamps_generators.py
+++ b/utils/timestamps_generators.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+import pytz
+
+def timestamps_gen(beginTime, endTime, date) :
+    local_tz = pytz.timezone('America/El_Salvador')
+
+    # Build datetime with local time zone
+    dt_inicio_local = local_tz.localize(datetime.strptime(f"{date} {beginTime}", "%Y-%m-%d %H:%M"))
+    dt_fin_local = local_tz.localize(datetime.strptime(f"{date} {endTime}", "%Y-%m-%d %H:%M"))
+
+    # Convert to UTC
+    dt_inicio_utc = dt_inicio_local.astimezone(pytz.utc)
+    dt_fin_utc = dt_fin_local.astimezone(pytz.utc)
+
+    # Obtain timestampos in seconds
+    begin_timestamp = int(dt_inicio_utc.timestamp())
+    end_timestamp = int(dt_fin_utc.timestamp())
+
+    return begin_timestamp, end_timestamp


### PR DESCRIPTION
## 📄 Descripción del PR

Se implementó la validación de los campos `nbf` (Not Before) y `exp` (Expiration) en los tokens de sesión de **Jitsi**, específicamente para los roles de **doctor** y **paciente**.

### 📌 Cambios realizados:

- 📦 Se creó el archivo `utils/timestamps_generators.py` con una función encargada de construir los timestamps de `nbf` y `exp` a partir de los datos del `Appointment`, utilizando la fecha y los horarios de consulta asignados.

- 🔧 Se modificó `utils/jitsi_utils.py`:
  - Se agregó a la función `generate_jitsi_jwt` los parámetros `nbf_time` y `exp_time`, que se incluyen en el payload del token JWT.
  - Se actualizó `get_jitsi_meeting_link_and_token` para recibir y propagar estos nuevos parámetros.

- 🩺 En el controlador:
  - Se ajustaron las funciones `createAppointment` y `get_doctor_jitsi_info` para generar y pasar los valores de `nbf_time` y `exp_time`, utilizando la función creada en `timestamps_generators.py`, en función del día del appointment y su slot horario.

### 🎯 Objetivo

Con estos cambios se garantiza que los enlaces y sesiones de Jitsi solo sean válidos dentro del rango de tiempo correspondiente a la cita médica agendada, fortaleciendo así la seguridad y control de acceso a las reuniones.