### PR TITLE
fix: updated tests to work with new logic added to the API

### DIFF
--- a/tests/test_appointment_controller.py
+++ b/tests/test_appointment_controller.py
@@ -48,7 +48,7 @@ def mock_service():
 def mock_slot():
     return Slot(
         Id=1,
-        Time="09:00",
+        Time="09:00 - 10:00",
         Status="Available"
     )
 
@@ -91,8 +91,15 @@ async def test_create_appointment_presential(mock_db, sample_appointment_data, m
     assert result.MeetingLink is None
 
 @pytest.mark.asyncio
-async def test_create_appointment_invalid_modality(mock_db, sample_appointment_data):
+async def test_create_appointment_invalid_modality(mock_db, sample_appointment_data, mock_patient, mock_service, mock_slot):
     sample_appointment_data.Modality = "InvalidModality"
+    
+    # Configurar los mocks para que llegue hasta la validación de modalidad
+    mock_db.execute.return_value.scalars.return_value.first.side_effect = [
+        mock_patient,
+        mock_slot,
+        mock_service
+    ]
     
     with pytest.raises(HTTPException) as exc_info:
         await createAppointment(sample_appointment_data, mock_db)

--- a/tests/test_appointment_controller.py
+++ b/tests/test_appointment_controller.py
@@ -61,8 +61,13 @@ async def test_create_appointment_virtual(mock_db, sample_appointment_data, mock
         mock_service
     ]
 
-    # Mock del envío de correo
-    with patch('controllers.appointmentController.BuildMail') as mock_mail:
+    # Mock del envío de correo y Jitsi functions
+    with patch('controllers.appointmentController.BuildMail') as mock_mail, \
+         patch('controllers.appointmentController.generate_jitsi_jwt') as mock_jwt:
+        
+        # Mock the JWT generation
+        mock_jwt.return_value = "test-jwt-token"
+        
         result = await createAppointment(sample_appointment_data, mock_db)
         
         # Verificaciones

--- a/tests/test_appointment_routes.py
+++ b/tests/test_appointment_routes.py
@@ -77,10 +77,9 @@ def test_get_total_pending_appointments():
 
 def test_get_jitsi_token():
     appointment_id = 1
-    patient_name = "John Doe"
-    response = client.get(f"/jitsi-token?appointmentId={appointment_id}&patientName={patient_name}")
+    response = client.get(f"/appointment/{appointment_id}/jitsi/doctor")
     assert response.status_code == 200
     data = response.json()
-    assert "meetingId" in data
-    assert "meetingUrl" in data
-    assert f"telemedicina-johndoe-{appointment_id}" in data["meetingId"] 
+    assert "meeting_id" in data
+    assert "meeting_url" in data
+    assert "token" in data 

--- a/tests/test_appointment_routes.py
+++ b/tests/test_appointment_routes.py
@@ -19,8 +19,13 @@ def appointment_data():
     }
 
 def test_create_appointment_endpoint(appointment_data):
-    # Mock the BuildMail class
-    with patch('controllers.appointmentController.BuildMail') as mock_mail:
+    # Mock the BuildMail class and Jitsi functions
+    with patch('controllers.appointmentController.BuildMail') as mock_mail, \
+         patch('controllers.appointmentController.generate_jitsi_jwt') as mock_jwt:
+        
+        # Mock the JWT generation
+        mock_jwt.return_value = "test-jwt-token"
+        
         response = client.post("/appointment", json=appointment_data)
         assert response.status_code == 200
         data = response.json()
@@ -77,9 +82,17 @@ def test_get_total_pending_appointments():
 
 def test_get_jitsi_token():
     appointment_id = 1
-    response = client.get(f"/appointment/{appointment_id}/jitsi/doctor")
-    assert response.status_code == 200
-    data = response.json()
-    assert "meeting_id" in data
-    assert "meeting_url" in data
-    assert "token" in data 
+    # Mock the Jitsi functions
+    with patch('controllers.appointmentController.get_jitsi_meeting_link_and_token') as mock_jitsi:
+        mock_jitsi.return_value = {
+            "meeting_id": "telemedicina-johndoe-1",
+            "meeting_url": "https://8x8.vc/test-app-id/telemedicina-johndoe-1",
+            "token": "test-jwt-token"
+        }
+        
+        response = client.get(f"/appointment/{appointment_id}/jitsi/doctor")
+        assert response.status_code == 200
+        data = response.json()
+        assert "meeting_id" in data
+        assert "meeting_url" in data
+        assert "token" in data 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from main import app
 from config.models import Patient, Appointment, Slot, Service
 from config.database import SessionLocal
-from utils.jitsi_utils import generate_meeting_id, create_jitsi_meeting
+from utils.jitsi_utils import generate_meeting_id
 import uuid
 
 # Configuración inicial
@@ -71,8 +71,10 @@ async def test_virtual_appointment_jitsi_integration(mocker):
 
     # Verificar que el enlace es válido según el formato esperado
     expected_meeting_id = generate_meeting_id(patient["Name"], appointment["Id"])
-    expected_url = f"https://meet.jit.si/{expected_meeting_id}"
-    assert appointment["MeetingLink"] == expected_url
+    # Updated to match the new domain format used in the controller
+    expected_url = f"https://8x8.vc/{mocker.patch('os.getenv', return_value='test-app-id').return_value}/{expected_meeting_id}"
+    assert "8x8.vc" in appointment["MeetingLink"]
+    assert expected_meeting_id in appointment["MeetingLink"]
     
     # Verify email was attempted to be sent
     mock_build_mail.assert_called_once()
@@ -83,7 +85,9 @@ async def test_virtual_appointment_jitsi_integration(mocker):
         credentials=mocker.ANY,
         paciente=patient["Name"],
         fecha=str(date.today()),
-        enlace=appointment["MeetingLink"]
+        enlace=appointment["MeetingLink"],
+        tipo="confirmacion",
+        hora=mocker.ANY,
     )
 
 @pytest.mark.asyncio
@@ -126,7 +130,9 @@ async def test_virtual_appointment_email_notification(mocker):
         credentials=mocker.ANY,
         paciente=patient["Name"],
         fecha=str(date.today()),
-        enlace=appointment["MeetingLink"]
+        enlace=appointment["MeetingLink"],
+        tipo="confirmacion",
+        hora=mocker.ANY,
     )
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -35,8 +35,10 @@ async def test_patient():
 @pytest.mark.asyncio
 async def test_virtual_appointment_jitsi_integration(mocker):
     """Prueba la integración completa de una cita virtual con Jitsi"""
-    # Mock the BuildMail class
+    # Mock the BuildMail class and Jitsi functions
     mock_build_mail = mocker.patch('controllers.appointmentController.BuildMail')
+    mock_jwt = mocker.patch('controllers.appointmentController.generate_jitsi_jwt')
+    mock_jwt.return_value = "test-jwt-token"
     
     unique_id = str(uuid.uuid4())[:8]
     patient_data = {
@@ -108,6 +110,8 @@ async def test_virtual_appointment_email_notification(mocker):
     
     # Mock de BuildMail en el módulo donde se USA (controllers.appointmentController)
     mock_build_mail = mocker.patch('controllers.appointmentController.BuildMail')
+    mock_jwt = mocker.patch('controllers.appointmentController.generate_jitsi_jwt')
+    mock_jwt.return_value = "test-jwt-token"
     
     appointment_data = {
         "Problem": "Consulta Virtual con Notificación por Email",

--- a/tests/test_jitsi.py
+++ b/tests/test_jitsi.py
@@ -1,27 +1,104 @@
 import pytest
-from utils.jitsi_utils import generate_meeting_id, create_jitsi_meeting
+from unittest.mock import patch, MagicMock
+from utils.jitsi_utils import generate_meeting_id, get_jitsi_meeting_link_and_token, generate_jitsi_jwt
 
 def test_generate_meeting_id():
     # Test con nombre simple
     assert generate_meeting_id("John Doe", 123) == "telemedicina-johndoe-123"
     
-    # Test con caracteres especiales
+    # Test con caracteres especiales - la función solo reemplaza 'ñ' con 'n', mantiene 'í' y 'é'
     result = generate_meeting_id("María José", 456)
-    assert result == "telemedicina-mariajose-456" or result == "telemedicina-maríajosé-456"
+    assert result == "telemedicina-maríajosé-456"
     
     # Test con espacios múltiples
     assert generate_meeting_id("John    Doe", 789) == "telemedicina-johndoe-789"
 
-def test_create_jitsi_meeting():
-    # Test creación básica de reunión
-    result = create_jitsi_meeting("John Doe", 123)
-    expected_id = "telemedicina-johndoe-123"
-    assert result["meeting_id"] == expected_id
-    assert result["meeting_url"] == f"https://meet.jit.si/{expected_id}"
-    assert result["token"] is None
+@patch('utils.jitsi_utils.read_private_key')
+@patch('utils.jitsi_utils.JITSI_DOMAIN', '8x8.vc')
+@patch('utils.jitsi_utils.JITSI_APP_ID', 'test-app-id')
+@patch('utils.jitsi_utils.JITSI_KID', 'test-kid')
+def test_generate_jitsi_jwt(mock_read_private_key):
+    # Mock the private key reading
+    mock_read_private_key.return_value = "test-private-key"
+    
+    # Mock the JaaSJwtBuilder
+    with patch('utils.jitsi_utils.JaaSJwtBuilder') as mock_builder_class:
+        mock_builder = MagicMock()
+        mock_builder_class.return_value = mock_builder
+        mock_builder.withAppID.return_value = mock_builder
+        mock_builder.withApiKey.return_value = mock_builder
+        mock_builder.withRoomName.return_value = mock_builder
+        mock_builder.withUserName.return_value = mock_builder
+        mock_builder.withUserId.return_value = mock_builder
+        mock_builder.withModerator.return_value = mock_builder
+        mock_builder.withLobbyEnabled.return_value = mock_builder
+        mock_builder.withNbfTime.return_value = mock_builder
+        mock_builder.withExpTime.return_value = mock_builder
+        mock_builder.signWith.return_value = "test-jwt-token"
+        
+        # Test JWT generation
+        result = generate_jitsi_jwt(
+            user_name="John Doe",
+            user_id=123,
+            room_name="telemedicina-johndoe-123",
+            is_moderator=True,
+            nbf_time=1234567890,
+            exp_time=1234567890
+        )
+        
+        assert result == "test-jwt-token"
+        mock_builder.signWith.assert_called_once_with("test-private-key")
 
-    # Test con caracteres especiales
-    result = create_jitsi_meeting("María José", 456)
-    # Aceptamos ambas formas ya que la normalización de caracteres puede variar
-    assert result["meeting_id"] in ["telemedicina-mariajose-456", "telemedicina-maríajosé-456"]
-    assert result["meeting_url"].startswith("https://meet.jit.si/telemedicina-") 
+@patch('utils.jitsi_utils.read_private_key')
+@patch('utils.jitsi_utils.JITSI_DOMAIN', '8x8.vc')
+@patch('utils.jitsi_utils.JITSI_APP_ID', 'test-app-id')
+@patch('utils.jitsi_utils.JITSI_KID', 'test-kid')
+def test_get_jitsi_meeting_link_and_token(mock_read_private_key):
+    # Mock the private key reading
+    mock_read_private_key.return_value = "test-private-key"
+    
+    # Mock the JaaSJwtBuilder
+    with patch('utils.jitsi_utils.JaaSJwtBuilder') as mock_builder_class:
+        mock_builder = MagicMock()
+        mock_builder_class.return_value = mock_builder
+        mock_builder.withAppID.return_value = mock_builder
+        mock_builder.withApiKey.return_value = mock_builder
+        mock_builder.withRoomName.return_value = mock_builder
+        mock_builder.withUserName.return_value = mock_builder
+        mock_builder.withUserId.return_value = mock_builder
+        mock_builder.withModerator.return_value = mock_builder
+        mock_builder.withLobbyEnabled.return_value = mock_builder
+        mock_builder.withNbfTime.return_value = mock_builder
+        mock_builder.withExpTime.return_value = mock_builder
+        mock_builder.signWith.return_value = "test-jwt-token"
+        
+        # Test creación básica de reunión
+        result = get_jitsi_meeting_link_and_token(
+            user_name="John Doe",
+            user_id=123,
+            appointment_id=123,
+            patient_name="John Doe",
+            is_moderator=True,
+            nbf_time=1234567890,
+            exp_time=1234567890
+        )
+        
+        expected_id = "telemedicina-johndoe-123"
+        assert result["meeting_id"] == expected_id
+        assert result["meeting_url"] == f"https://8x8.vc/test-app-id/{expected_id}"
+        assert result["token"] == "test-jwt-token"
+
+        # Test con caracteres especiales - actualizado para coincidir con el comportamiento real
+        result = get_jitsi_meeting_link_and_token(
+            user_name="María José",
+            user_id=456,
+            appointment_id=456,
+            patient_name="María José",
+            is_moderator=False,
+            nbf_time=1234567890,
+            exp_time=1234567890
+        )
+        
+        assert result["meeting_id"] == "telemedicina-maríajosé-456"
+        assert result["meeting_url"].startswith("https://8x8.vc/test-app-id/telemedicina-")
+        assert result["token"] == "test-jwt-token" 


### PR DESCRIPTION
Este Pull Request introduce varias actualizaciones en la suite de pruebas para la funcionalidad relacionada con citas, enfocándose en la integración con Jitsi, mejoras en las pruebas y configuraciones de mocks. Los cambios mejoran la cobertura de las pruebas, actualizan el dominio de Jitsi y la lógica de generación de tokens, y optimizan el mockeo de dependencias.

### Actualizaciones en la Integración con Jitsi:
* Se actualizó el dominio de Jitsi de `meet.jit.si` a `8x8.vc` tanto en las pruebas de integración como en las funciones utilitarias. Esto incluye cambios en el formato esperado del enlace de la reunión y en la lógica de generación de tokens. (`[[1]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL74-R77)`, `[[2]](diffhunk://#diff-51a42f0bfe8fd85d542185ba74812c7cad53c2dcbc24c3ae3ce959271faacfd7L2-R104)`)
* Se añadieron pruebas para `generate_jitsi_jwt` y `get_jitsi_meeting_link_and_token` para validar la generación de JWT y la creación del enlace de reunión con el nuevo dominio. (`[tests/test_jitsi.pyL2-R104](diffhunk://#diff-51a42f0bfe8fd85d542185ba74812c7cad53c2dcbc24c3ae3ce959271faacfd7L2-R104)`)

### Mejoras en las Pruebas:
* Se modificó `test_create_appointment_invalid_modality` para incluir mocks adicionales (`mock_patient`, `mock_service`, `mock_slot`) y mejorar la validación de modalidades. (`[tests/test_appointment_controller.pyL94-R103](diffhunk://#diff-fc086333bfe26084cca424eddec5beb5a6c19e4cdeeb59c4165ee91054f8831dL94-R103)`)
* Se ajustó `test_get_jitsi_token` para alinearlo con el endpoint de la API actualizado y la nueva estructura de respuesta, incluyendo cambios en los nombres de las claves (`meeting_id`, `meeting_url`, `token`). (`[tests/test_appointment_routes.pyL80-R85](diffhunk://#diff-67ec4c2e6d135d2a7b8577791b066d59f68c998bed788d51f0841cca28d4afacL80-R85)`)

### Actualizaciones de Mocks y Dependencias:
* Se actualizó `mock_slot` para devolver un rango de horario (`09:00 - 10:00`) en vez de un único valor de hora. (`[tests/test_appointment_controller.pyL51-R51](diffhunk://#diff-fc086333bfe26084cca424eddec5beb5a6c19e4cdeeb59c4165ee91054f8831dL51-R51)`)
* Se eliminaron imports no utilizados, como `create_jitsi_meeting`, de las pruebas de integración para reflejar las funciones utilitarias actualizadas. (`[tests/test_integration.pyL8-R8](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL8-R8)`)

### Pruebas de Notificación por Correo Electrónico:
* Se mejoraron las pruebas de notificación por correo electrónico añadiendo nuevos parámetros (`tipo`, `hora`) para verificar campos adicionales en el payload del correo simulado. (`[[1]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL86-R90)`, `[[2]](diffhunk://#diff-98bfe78f0e8d895dd454b5eef6f6485a80526776ad3b6525a14117029bd1eacbL129-R135)`)